### PR TITLE
Feature/modify for see3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 cmake-build-*
 .cmake-build-*
+.vscode/*

--- a/include/opencv_cam/camera_context.hpp
+++ b/include/opencv_cam/camera_context.hpp
@@ -16,6 +16,7 @@ namespace opencv_cam
   CXT_MACRO_MEMBER(filename, std::string, "")                     /* Filename */ \
   \
   CXT_MACRO_MEMBER(index, int, 0)                                 /* Device index, see cv::VideoCaptureAPIs */ \
+  CXT_MACRO_MEMBER(device, std::string, "")                       /* Device name */ \
   CXT_MACRO_MEMBER(width, int, 0)                                 /* Device width */ \
   CXT_MACRO_MEMBER(height, int, 0)                                /* Device height */ \
   \

--- a/include/opencv_cam/opencv_cam_node.hpp
+++ b/include/opencv_cam/opencv_cam_node.hpp
@@ -1,7 +1,7 @@
 #ifndef OPENCV_CAM_HPP
 #define OPENCV_CAM_HPP
 
-
+#include <opencv2/imgproc.hpp>
 #include "opencv2/highgui/highgui.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
@@ -24,8 +24,10 @@ namespace opencv_cam
 
     int publish_fps_;
     rclcpp::Time next_stamp_;
+    bool see3cam_flag_;
 
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_ir_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
 
   public:
@@ -37,6 +39,7 @@ namespace opencv_cam
   private:
 
     void validate_parameters();
+    bool SeparatingRGBIRBuffers(cv::Mat frame, cv::Mat* IRImageCU83, cv::Mat* RGBImageCU83, int *RGBBufferSizeCU83, int *IRBufferSizeCU83);
 
     void loop();
   };

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
 
     <name>opencv_cam</name>
     <version>0.2.0</version>
-    <description>OpenCV camera driver</description>
+    <description>OpenCV and See3cam_CU83 ROS2 camera driver</description>
 
     <maintainer email="clyde@mcqueen.net">Clyde McQueen</maintainer>
     <license>BSD</license>

--- a/src/opencv_cam_node.cpp
+++ b/src/opencv_cam_node.cpp
@@ -87,17 +87,14 @@ namespace opencv_cam
       next_stamp_ = now();
 
     } else {
+      capture_ = std::make_shared<cv::VideoCapture>(cxt_.device_, cv::CAP_V4L2);
       if (see3cam_flag_) {
-        capture_ = std::make_shared<cv::VideoCapture>(cxt_.index_, cv::CAP_V4L2);
         capture_->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y','1','6',' '));
         capture_->set(cv::CAP_PROP_CONVERT_RGB, false);
       }
-      else {
-        capture_ = std::make_shared<cv::VideoCapture>(cxt_.index_);
-      }
 
       if (!capture_->isOpened()) {
-        RCLCPP_ERROR(get_logger(), "cannot open device %d", cxt_.index_);
+        RCLCPP_ERROR(get_logger(), "cannot open device %s", cxt_.device_.c_str());
         return;
       }
 


### PR DESCRIPTION
Wrapper for RGBIR camera. Set it up to only support econ in 1080p RGB/IR dual mode, and it should still support running any other camera (we might want to switch to this in place of the camera wrapper we are currently using for Mapirs but can sort that out later). Also modified so you set device by path instead of index.

# Setup
Use this repos file: 
[newcamera.txt](https://github.com/user-attachments/files/18526734/newcamera.txt)
See also the PR for vehicle_launch

# Test
Erin tested with both Mapir and econ, but since Gus has only Mapir, run that test. Plug Mapir into computer and run:
```
ros2 launch vehicle_launch mapir_opencv.launch
```
View images and hz in Foxglove:
![Screenshot from 2025-01-23 15-40-58](https://github.com/user-attachments/assets/91eb16a0-bec0-422f-855d-beebd0a885df)
